### PR TITLE
Nodiff test

### DIFF
--- a/test.diff
+++ b/test.diff
@@ -1,0 +1,1 @@
+this should display in a PR

--- a/test.nodiff
+++ b/test.nodiff
@@ -1,0 +1,1 @@
+this should not display in a PR


### PR DESCRIPTION
two files were created `test.nodiff` and `test.diff`. 

The results should be that `test.nodiff` is not displayed in the PR